### PR TITLE
Add display of fish intel progress to livesplit component

### DIFF
--- a/NieRAutoIntelTracker/GameMemory.cs
+++ b/NieRAutoIntelTracker/GameMemory.cs
@@ -26,11 +26,14 @@ namespace NieRAutoIntelTracker
 
         private IntelDisplay _intelDisplay;
 
-        public GameMemory(IntelDisplay intelDisplay)
+        private Action<int> _fishCountDisplay;
+
+        public GameMemory(IntelDisplay intelDisplay, Action<int> fishCountDisplay)
         {
             _intelFishPtr = new DeepPointer(0x198452C); // 0x197C460
             _intelFishPtrDebug = new DeepPointer(0x25AF8AC); // 0x25A77E0
             _intelDisplay = intelDisplay;
+            _fishCountDisplay = fishCountDisplay;
             IntelFishCurrent = new byte[1];
             IntelUnitCurrent = new byte[1];
         }
@@ -111,13 +114,14 @@ namespace NieRAutoIntelTracker
 
                     while (!game.HasExited)
                     {
-                        ulong _intelFishCurrent;
                         IntelFishOld = IntelFishCurrent;
                         IntelFishCurrent = FishPtr.DerefBytes(game, 8);
 
                         if (!IntelFishCurrent.SequenceEqual(IntelFishOld))
                         {
-                            this._intelDisplay.UpdateFishIntel(IntelFishCurrent);
+                            int fishCount = IntelFishCurrent.Select(s => BitCount.PrecomputedBitcount(s)).Sum();
+                            this._fishCountDisplay(fishCount);
+                            this._intelDisplay.UpdateFishIntel(IntelFishCurrent, fishCount);
                         }
 
                         IntelUnitOld = IntelUnitCurrent;

--- a/NieRAutoIntelTracker/IntelDisplay.cs
+++ b/NieRAutoIntelTracker/IntelDisplay.cs
@@ -30,7 +30,7 @@ namespace NieRAutoIntelTracker
             this.Visible = visible;
         }
 
-        public void UpdateFishIntel(byte[] buffer)
+        public void UpdateFishIntel(byte[] buffer, int count)
         {
             this.checkBoxMackerelM.Checked = this.checkBoxMackerelM2.Checked = (buffer[0] & (byte)FishIntel.MACKEREL_MACHINE) != 0;
             this.checkBoxCoelacanthM.Checked = (buffer[0] & (byte)FishIntel.COELACANTH_MACHINE) != 0;
@@ -81,8 +81,7 @@ namespace NieRAutoIntelTracker
             this.checkBoxArowanaM.Checked = (buffer[7] & (byte)FishIntel.AROWANA_MACHINE) != 0;
             this.checkBoxHorseshoeCrabM.Checked = (buffer[7] & (byte)FishIntel.HORSESHOE_CRAB_MACHINE) != 0;
 
-            int currentCount = buffer.Select(s => BitCount.PrecomputedBitcount(s)).Sum();
-            this.textProgressBarFish.Value = currentCount;
+            this.textProgressBarFish.Value = count;
         }
 
         public void UpdateDebugDisplay(string text)

--- a/NieRAutoIntelTracker/NieRAutoIntelTrackerComponent.cs
+++ b/NieRAutoIntelTracker/NieRAutoIntelTrackerComponent.cs
@@ -20,6 +20,20 @@ namespace NieRAutoIntelTracker
         private GameMemory _gameMemory;
         private IntelDisplay _intelDisplay;
 
+        protected InfoTextComponent InternalComponent { get; set; }
+
+        public string ComponentName => "NieR:Automata Intel Tracker";
+
+        public float PaddingTop => InternalComponent.PaddingTop;
+        public float PaddingLeft => InternalComponent.PaddingLeft;
+        public float PaddingBottom => InternalComponent.PaddingBottom;
+        public float PaddingRight => InternalComponent.PaddingRight;
+
+        public float VerticalHeight => InternalComponent.VerticalHeight;
+        public float MinimumWidth => InternalComponent.MinimumWidth;
+        public float HorizontalWidth => InternalComponent.HorizontalWidth;
+        public float MinimumHeight => InternalComponent.MinimumHeight;
+
         public NieRAutoIntelTrackerComponent(LiveSplitState state)
         {
             this.state = state;
@@ -27,11 +41,10 @@ namespace NieRAutoIntelTracker
             this._intelDisplay = new IntelDisplay();
             this.settings = new Settings(visible => _intelDisplay.SetVisibility(visible));
 
-            this._gameMemory = new GameMemory(_intelDisplay);
+            this._gameMemory = new GameMemory(_intelDisplay, fishCount => RefreshFishCount(fishCount));
             this._gameMemory.StartMonitoring();
 
-            HorizontalWidth = 0;
-            VerticalHeight = 0;
+            InternalComponent = new InfoTextComponent("Fish Intel", "Loading...");
 
             ContextMenuControls = new Dictionary<string, Action>
             {
@@ -39,35 +52,42 @@ namespace NieRAutoIntelTracker
             };
         }
 
-        public string ComponentName => "NieR:Automata Intel Tracker";
-
-        public float HorizontalWidth { get; set; }
-
-        public float MinimumHeight { get; set; }
-
-        public float VerticalHeight { get; set; }
-
-        public float MinimumWidth { get; set; }
-
-        public float PaddingTop { get; set; }
-
-        public float PaddingBottom { get; set; }
-
-        public float PaddingLeft { get; set; }
-
-        public float PaddingRight { get; set; }
-
         public IDictionary<string, Action> ContextMenuControls { get; set; }
+
+        private void PrepareDraw(LiveSplitState state, LayoutMode mode)
+        {
+            InternalComponent.DisplayTwoRows = false;
+
+            InternalComponent.NameLabel.HasShadow
+                = InternalComponent.ValueLabel.HasShadow
+                = state.LayoutSettings.DropShadows;
+
+            InternalComponent.InformationName = "Fish Intel";
+            InternalComponent.AlternateNameText = new[]
+            {
+                "Fish"
+            };
+            InternalComponent.NameLabel.HorizontalAlignment = StringAlignment.Near;
+            InternalComponent.ValueLabel.HorizontalAlignment = StringAlignment.Far;
+            InternalComponent.NameLabel.VerticalAlignment =
+                mode == LayoutMode.Horizontal ? StringAlignment.Near : StringAlignment.Center;
+            InternalComponent.ValueLabel.VerticalAlignment =
+                mode == LayoutMode.Horizontal ? StringAlignment.Far : StringAlignment.Center;
+            
+            InternalComponent.NameLabel.ForeColor = state.LayoutSettings.TextColor;
+            InternalComponent.ValueLabel.ForeColor = state.LayoutSettings.TextColor;
+        }
 
         public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
         {
-            SolidBrush brush = new SolidBrush(state.LayoutSettings.TextColor);
-            g.DrawString(this.ComponentName, state.LayoutSettings.TextFont, brush, 0, 0);
+            PrepareDraw(state, LayoutMode.Horizontal);
+            InternalComponent.DrawHorizontal(g, state, height, clipRegion);
         }
 
         public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
         {
-            DrawHorizontal(g, state, width, clipRegion);
+            PrepareDraw(state, LayoutMode.Vertical);
+            InternalComponent.DrawVertical(g, state, width, clipRegion);
         }
 
         public XmlNode GetSettings(XmlDocument document)
@@ -87,7 +107,12 @@ namespace NieRAutoIntelTracker
 
         public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
         {
+            InternalComponent.Update(invalidator, state, width, height, mode);
+        }
 
+        public void RefreshFishCount(int fishCount)
+        {
+            InternalComponent.InformationValue = fishCount + " / 43";
         }
 
         #region IDisposable Support

--- a/NieRAutoIntelTracker/NieRAutoIntelTrackerFactory.cs
+++ b/NieRAutoIntelTracker/NieRAutoIntelTrackerFactory.cs
@@ -24,7 +24,7 @@ namespace NieRAutoIntelTracker
 
         public string UpdateName => this.ComponentName;
         public string UpdateURL => "";
-        public Version Version => Version.Parse("0.3");
+        public Version Version => Version.Parse("0.4");
         public string XMLURL => UpdateURL + "";
     }
 }


### PR DESCRIPTION
v0.4 - adds Fish Intel count directly to the LiveSplit component for `All Fishable Items` category.